### PR TITLE
Change usize to u64 in various places to support 32-bit compilation.

### DIFF
--- a/lru-disk-cache/src/lib.rs
+++ b/lru-disk-cache/src/lib.rs
@@ -128,7 +128,7 @@ impl LruDiskCache {
     ///
     /// The cache is not observant of changes to files under `path` from external sources, it
     /// expects to have sole maintence of the contents.
-    pub fn new<T>(path: T, size: usize) -> Result<Self>
+    pub fn new<T>(path: T, size: u64) -> Result<Self>
         where PathBuf: From<T>
     {
         LruDiskCache {
@@ -138,10 +138,10 @@ impl LruDiskCache {
     }
 
     /// Return the current size of all the files in the cache.
-    pub fn size(&self) -> usize { self.lru.size() }
+    pub fn size(&self) -> u64 { self.lru.size() }
 
     /// Return the maximum size of the cache.
-    pub fn capacity(&self) -> usize { self.lru.capacity() }
+    pub fn capacity(&self) -> u64 { self.lru.capacity() }
 
     /// Return the path in which the cache is stored.
     pub fn path(&self) -> &Path { self.root.as_path() }

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -54,7 +54,7 @@ const APP_INFO: AppInfo = AppInfo {
     author: "Mozilla",
 };
 
-const TEN_GIGS: usize = 10 * 1024 * 1024 * 1024;
+const TEN_GIGS: u64 = 10 * 1024 * 1024 * 1024;
 
 /// Result of a cache lookup.
 pub enum Cache {
@@ -170,18 +170,18 @@ pub trait Storage {
     fn location(&self) -> String;
 
     /// Get the current storage usage, if applicable.
-    fn current_size(&self) -> Option<usize>;
+    fn current_size(&self) -> Option<u64>;
 
     /// Get the maximum storage size, if applicable.
-    fn max_size(&self) -> Option<usize>;
+    fn max_size(&self) -> Option<u64>;
 }
 
-fn parse_size(val: &str) -> Option<usize> {
+fn parse_size(val: &str) -> Option<u64> {
     let re = Regex::new(r"^(\d+)([KMGT])$").unwrap();
     re.captures(val)
         .and_then(|caps| {
             caps.get(1)
-                .and_then(|size| usize::from_str(size.as_str()).ok())
+                .and_then(|size| u64::from_str(size.as_str()).ok())
                 .and_then(|size| Some((size, caps.get(2))))
         })
         .and_then(|(size, suffix)| {
@@ -300,7 +300,7 @@ pub fn storage_from_environment(pool: &CpuPool, _handle: &Handle) -> Arc<Storage
         // Fall back to something, even if it's not very good.
         .unwrap_or(env::temp_dir().join("sccache_cache"));
     trace!("Using DiskCache({:?})", d);
-    let cache_size = env::var("SCCACHE_CACHE_SIZE")
+    let cache_size: u64 = env::var("SCCACHE_CACHE_SIZE")
         .ok()
         .and_then(|v| parse_size(&v))
         .unwrap_or(TEN_GIGS);

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -40,7 +40,7 @@ pub struct DiskCache {
 impl DiskCache {
     /// Create a new `DiskCache` rooted at `root`, with `max_size` as the maximum cache size on-disk, in bytes.
     pub fn new<T: AsRef<OsStr>>(root: &T,
-                                max_size: usize,
+                                max_size: u64,
                                 pool: &CpuPool) -> DiskCache {
         DiskCache {
             //TODO: change this function to return a Result
@@ -98,6 +98,6 @@ impl Storage for DiskCache {
         format!("Local disk: {:?}", self.lru.lock().unwrap().path())
     }
 
-    fn current_size(&self) -> Option<usize> { Some(self.lru.lock().unwrap().size()) }
-    fn max_size(&self) -> Option<usize> { Some(self.lru.lock().unwrap().capacity()) }
+    fn current_size(&self) -> Option<u64> { Some(self.lru.lock().unwrap().size()) }
+    fn max_size(&self) -> Option<u64> { Some(self.lru.lock().unwrap().capacity()) }
 }

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -110,6 +110,6 @@ impl Storage for S3Cache {
         format!("S3, bucket: {}", self.bucket)
     }
 
-    fn current_size(&self) -> Option<usize> { None }
-    fn max_size(&self) -> Option<usize> { None }
+    fn current_size(&self) -> Option<u64> { None }
+    fn max_size(&self) -> Option<u64> { None }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -698,8 +698,8 @@ pub struct ServerStats {
 pub struct ServerInfo {
     pub stats: ServerStats,
     pub cache_location: String,
-    pub cache_size: Option<usize>,
-    pub max_cache_size: Option<usize>,
+    pub cache_size: Option<u64>,
+    pub max_cache_size: Option<u64>,
 }
 
 impl Default for ServerStats {


### PR DESCRIPTION
Makes it possible to compile with target=i686-pc-windows-msvc on Windows.