### PR TITLE
Fix tests and --features=all compilation related to 32-bit support.

### DIFF
--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -102,7 +102,7 @@ impl Storage for RedisCache {
 
     /// Returns the current cache size. This value is aquired via
     /// the Redis INFO command (used_memory).
-    fn current_size(&self) -> Option<usize> {
+    fn current_size(&self) -> Option<u64> {
         self.connect().ok()
             .and_then(|c| cmd("INFO").query(&c).ok())
             .and_then(|i: InfoDict| i.get("used_memory"))
@@ -111,13 +111,13 @@ impl Storage for RedisCache {
     /// Returns the maximum cache size. This value is read via
     /// the Redis CONFIG command (maxmemory). If the server has no
     /// configured limit, the result is None.
-    fn max_size(&self) -> Option<usize> {
+    fn max_size(&self) -> Option<u64> {
         self.connect().ok()
             .and_then(|c| cmd("CONFIG").arg("GET").arg("maxmemory").query(&c).ok())
             .and_then(|h: HashMap<String, usize>| h.get("maxmemory").map(|s| *s))
             .and_then(|s| {
                 if s != 0 {
-                    Some(s)
+                    Some(s as u64)
                 } else {
                     None
                 }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -602,7 +602,7 @@ mod test {
     use std::io::Write;
     use std::sync::Arc;
     use std::time::Duration;
-    use std::usize;
+    use std::u64;
     use test::mock_storage::MockStorage;
     use test::utils::*;
     use tokio_core::reactor::Core;
@@ -707,7 +707,7 @@ mod test {
         let core = Core::new().unwrap();
         let handle = core.handle();
         let storage = DiskCache::new(&f.tempdir.path().join("cache"),
-                                     usize::MAX,
+                                     u64::MAX,
                                      &pool);
         let storage: Arc<Storage> = Arc::new(storage);
         // Pretend to be GCC.
@@ -788,7 +788,7 @@ mod test {
         let core = Core::new().unwrap();
         let handle = core.handle();
         let storage = DiskCache::new(&f.tempdir.path().join("cache"),
-                                     usize::MAX,
+                                     u64::MAX,
                                      &pool);
         let storage: Arc<Storage> = Arc::new(storage);
         // Pretend to be GCC.
@@ -934,7 +934,7 @@ mod test {
         let core = Core::new().unwrap();
         let handle = core.handle();
         let storage = DiskCache::new(&f.tempdir.path().join("cache"),
-                                     usize::MAX,
+                                     u64::MAX,
                                      &pool);
         let storage: Arc<Storage> = Arc::new(storage);
         // Pretend to be GCC.
@@ -1022,7 +1022,7 @@ mod test {
         let core = Core::new().unwrap();
         let handle = core.handle();
         let storage = DiskCache::new(&f.tempdir.path().join("cache"),
-                                     usize::MAX,
+                                     u64::MAX,
                                      &pool);
         let storage: Arc<Storage> = Arc::new(storage);
         // Pretend to be GCC.

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -46,6 +46,6 @@ impl Storage for MockStorage {
         f_ok(Duration::from_secs(0))
     }
     fn location(&self) -> String { "Mock Storage".to_string() }
-    fn current_size(&self) -> Option<usize> { None }
-    fn max_size(&self) -> Option<usize> { None }
+    fn current_size(&self) -> Option<u64> { None }
+    fn max_size(&self) -> Option<u64> { None }
 }

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -40,7 +40,7 @@ use std::process::Command;
 use std::sync::{Arc,Mutex,mpsc};
 use std::thread;
 use std::time::Duration;
-use std::usize;
+use std::u64;
 use test::utils::*;
 use tokio_core::reactor::Core;
 
@@ -50,7 +50,7 @@ struct ServerOptions {
     /// The server's idle shutdown timeout.
     idle_timeout: Option<u64>,
     /// The maximum size of the disk cache.
-    cache_size: Option<usize>,
+    cache_size: Option<u64>,
 }
 
 /// Run a server on a background thread, and return a tuple of useful things.
@@ -71,7 +71,7 @@ fn run_server_thread<T>(cache_dir: &Path, options: T)
     let cache_size = options.as_ref()
                             .and_then(|o| o.cache_size.as_ref())
                             .map(|s| *s)
-                            .unwrap_or(usize::MAX);
+                            .unwrap_or(u64::MAX);
     let pool = CpuPool::new(1);
     let storage = Arc::new(DiskCache::new(&cache_dir, cache_size, &pool));
 


### PR DESCRIPTION
https://github.com/goffrie/sccache/commit/4895e35bceacb804186849dc5e4f311a3bf38641 passes regular compilation, but fails to compile when passing --features=all and when running tests.  This diff adds additional fixes for these two cases.